### PR TITLE
Fixed sdl formula in upstream brew

### DIFF
--- a/code/Readme
+++ b/code/Readme
@@ -46,7 +46,7 @@ macOS compilation requirements:
 Run this in any macOS terminal:
 
 ````
-brew install https://raw.githubusercontent.com/lpla/homebrew-core/patch-1/Formula/sdl.rb --HEAD
+brew install sdl --HEAD
 curl https://gist.githubusercontent.com/lunaczp/1a2ee039ec36361a732e079037b08874/raw/74bbae0ddbe2e387eca077eb1af24dbafa374529/elf.h > /usr/local/include/elf.h
 ```
 


### PR DESCRIPTION
To compile this repository in macOS, latest SDL 1.2 code is needed. Until now, `brew` formula to install `sdl` latest `HEAD` was broken. The installation line in 'readme' was using the formula file I proposed in a pull request to `homebrew-core` (https://github.com/Homebrew/homebrew-core/pull/54630). But now it is merged (just a few minutes ago), so better use the standard command `brew install sdl --HEAD`.

Tested by the CI system in `homebrew-core` and manually in my laptop.